### PR TITLE
Capkgs dereference updates with shortRev addn

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -49,6 +49,7 @@ jobs:
           echo "${{secrets.NIX_SIGNING_KEY}}" > hydra_key
           nix develop \
           --ignore-environment \
+          --keep CI \
           --keep AWS_ACCESS_KEY_ID \
           --keep AWS_SECRET_ACCESS_KEY \
           --keep S3_ENDPOINT \

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -33,6 +33,8 @@ jobs:
           df -h
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: "${{github.head_ref || github.ref_name}}"
       - name: Install Nix
         uses: cachix/install-nix-action@v23
         with:
@@ -49,15 +51,15 @@ jobs:
           echo "${{secrets.NIX_SIGNING_KEY}}" > hydra_key
           nix develop \
           --ignore-environment \
-          --keep CI \
           --keep AWS_ACCESS_KEY_ID \
           --keep AWS_SECRET_ACCESS_KEY \
-          --keep S3_ENDPOINT \
+          --keep CI \
           --keep LOG_LEVEL \
+          --keep S3_ENDPOINT \
           --command just ci
         env:
           AWS_ACCESS_KEY_ID: "${{secrets.AWS_ACCESS_KEY_ID}}"
           AWS_SECRET_ACCESS_KEY: "${{secrets.AWS_SECRET_ACCESS_KEY}}"
-          S3_ENDPOINT: "${{secrets.S3_ENDPOINT}}"
-          NIX_SIGNING_KEY_FILE: "/home/runner/work/capkgs/capkgs/hydra_key"
           LOG_LEVEL: "debug"
+          NIX_SIGNING_KEY_FILE: "/home/runner/work/capkgs/capkgs/hydra_key"
+          S3_ENDPOINT: "${{secrets.S3_ENDPOINT}}"

--- a/Justfile
+++ b/Justfile
@@ -4,14 +4,14 @@ list:
 
 secret_key := env_var_or_default('NIX_SIGNING_KEY_FILE', "hydra_key")
 
-# Based on releases.json, upload the CA contents and update packages.json
+# Based on projects.json, upload the CA contents and update packages.json
 packages *ARGS:
     ./packages.cr \
         --to "s3://devx?secret-key={{secret_key}}&endpoint=${S3_ENDPOINT}&region=auto&compression=zstd" \
         --from-store https://cache.iog.io \
         --systems x86_64-linux
 
-# Based on releases.json, upload the CA contents and update packages.json
+# Based on projects.json, upload the CA contents and update packages.json
 ci:
     @just -v cache-download
     @just -v packages
@@ -29,11 +29,11 @@ cache-upload:
 
 rclone *ARGS:
     #!/usr/bin/env nu
-    $env.HOME = $env.PWD
+    if $env.CI? == "true" { $env.HOME = $env.PWD }
     mkdir .config/rclone
     rclone config create s3 s3 env_auth=true | save -f .config/rclone/rclone.conf
     rclone --s3-provider Cloudflare --s3-region auto --s3-endpoint $env.S3_ENDPOINT --verbose {{ARGS}}
-    
+
 push:
     git add packages.json
     git commit -m 'Update packages.json'

--- a/flake.nix
+++ b/flake.nix
@@ -8,8 +8,9 @@
       fragment = builtins.split "#" flakeUrl;
       parts = builtins.split "\\." (last fragment);
       name = last parts;
+      shortrev = builtins.substring 0 7 pkg.commit;
     in
-      sane "${name}-${pkg.org_name}-${pkg.repo_name}-${pkg.version}";
+      sane "${name}-${pkg.org_name}-${pkg.repo_name}-${pkg.version}-${shortrev}";
 
     packagesJson = fromJSON (readFile ./packages.json);
     validPackages = filterAttrs (flakeUrl: pkg: pkg ? system && !(pkg ? fail)) packagesJson;

--- a/packages.cr
+++ b/packages.cr
@@ -107,14 +107,15 @@ class CAPkgs
 
     # Ref patterns will not be automatically dereferenced.
     # To dereference, a ref pattern should have a suffix of: `\\^\\{\\}$`
-    # The resulting package name of the dereferenced pattern will include a `^{}` suffix
+    # The resulting package name from a dereferenced pattern will *NOT* include the `^{}` suffix.
+    # The shortRev in the package name can be used to infer dereferencing.
     refs_tags = ref_patterns.flat_map do |ref_pattern|
       regex = Regex.new(ref_pattern)
       result.stdout.lines
         .map { |line| line.strip.split }
         .select { |(rev, ref)| ref =~ regex }
         .map do |(rev, ref)|
-          [ref.sub(%r(^refs/[^/]+/), ""), rev]
+          [ref.sub(%r(^refs/[^/]+/), "").sub(%r(\^\{\}$), ""), rev]
         end
     end
 

--- a/packages.json
+++ b/packages.json
@@ -4841,6 +4841,118 @@
     "system": "x86_64-linux",
     "exeName": "cardano-smash-server"
   },
+  "github:IntersectMBO/cardano-db-sync/0edff13a734a0ae02a6d7a99d0f77d27413f3421#packages.x86_64-linux.\"cardano-db-sync:exe:cardano-db-sync\"": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.\"cardano-db-sync:exe:cardano-db-sync\"",
+    "version": "sancho-2-3-0",
+    "commit": "0edff13a734a0ae02a6d7a99d0f77d27413f3421",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-db-sync-exe-cardano-db-sync-13.2.0.0",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/4q1kj9w3iz9pw4l26jjq0bwvlqg4x4am-source/overlays/haskell-nix-extra/default.nix:55",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/lhzvzifdlhcasrk6cx0zs9bwdhiwhhad-cardano-db-sync-exe-cardano-db-sync-13.2.0.0",
+    "closure": {
+      "fromPath": "/nix/store/lhzvzifdlhcasrk6cx0zs9bwdhiwhhad-cardano-db-sync-exe-cardano-db-sync-13.2.0.0",
+      "toPath": "/nix/store/qpkdq10ya9pd9y90y5fy49v35wzkc6c8-cardano-db-sync-exe-cardano-db-sync-13.2.0.0",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-db-sync-exe-cardano-db-sync",
+    "system": "x86_64-linux",
+    "exeName": "cardano-db-sync"
+  },
+  "github:IntersectMBO/cardano-db-sync/0edff13a734a0ae02a6d7a99d0f77d27413f3421#packages.x86_64-linux.\"cardano-db-tool:exe:cardano-db-tool\"": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.\"cardano-db-tool:exe:cardano-db-tool\"",
+    "version": "sancho-2-3-0",
+    "commit": "0edff13a734a0ae02a6d7a99d0f77d27413f3421",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-db-tool-exe-cardano-db-tool-13.2.0.0",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/4q1kj9w3iz9pw4l26jjq0bwvlqg4x4am-source/overlays/haskell-nix-extra/default.nix:55",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/18v2bl5lnaynwxq624v02kg8f19pnw22-cardano-db-tool-exe-cardano-db-tool-13.2.0.0",
+    "closure": {
+      "fromPath": "/nix/store/18v2bl5lnaynwxq624v02kg8f19pnw22-cardano-db-tool-exe-cardano-db-tool-13.2.0.0",
+      "toPath": "/nix/store/rkg6xzfq8x94j44p7mvmph84q7qis7z6-cardano-db-tool-exe-cardano-db-tool-13.2.0.0",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-db-tool-exe-cardano-db-tool",
+    "system": "x86_64-linux",
+    "exeName": "cardano-db-tool"
+  },
+  "github:IntersectMBO/cardano-db-sync/0edff13a734a0ae02a6d7a99d0f77d27413f3421#packages.x86_64-linux.\"cardano-smash-server:exe:cardano-smash-server\"": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.\"cardano-smash-server:exe:cardano-smash-server\"",
+    "version": "sancho-2-3-0",
+    "commit": "0edff13a734a0ae02a6d7a99d0f77d27413f3421",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/4q1kj9w3iz9pw4l26jjq0bwvlqg4x4am-source/overlays/haskell-nix-extra/default.nix:55",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/ziq2cvpabwj2hl0yr61nwf190vcbx4a8-cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
+    "closure": {
+      "fromPath": "/nix/store/ziq2cvpabwj2hl0yr61nwf190vcbx4a8-cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
+      "toPath": "/nix/store/vxr7brh3fl2vnmsr207rn4dsv1sg371x-cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-smash-server-exe-cardano-smash-server",
+    "system": "x86_64-linux",
+    "exeName": "cardano-smash-server"
+  },
+  "github:IntersectMBO/cardano-db-sync/0edff13a734a0ae02a6d7a99d0f77d27413f3421#packages.x86_64-linux.cardano-smash-server-no-basic-auth": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-smash-server-no-basic-auth",
+    "version": "sancho-2-3-0",
+    "commit": "0edff13a734a0ae02a6d7a99d0f77d27413f3421",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/4q1kj9w3iz9pw4l26jjq0bwvlqg4x4am-source/overlays/haskell-nix-extra/default.nix:55",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/hn9pi82dx0rw2dwcs8kbacqspm2kis0y-cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
+    "closure": {
+      "fromPath": "/nix/store/hn9pi82dx0rw2dwcs8kbacqspm2kis0y-cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
+      "toPath": "/nix/store/4ax9bgj5qf07rw8r0lyld2mgny8nfcif-cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-smash-server-exe-cardano-smash-server",
+    "system": "x86_64-linux",
+    "exeName": "cardano-smash-server"
+  },
   "github:IntersectMBO/cardano-db-sync/1d0edc3e8986a287f654d39e407aa72b3c3d6bc0#packages.x86_64-linux.\"cardano-db-sync:exe:cardano-db-sync\"": {
     "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.\"cardano-db-sync:exe:cardano-db-sync\"",
     "version": "13.0.5",
@@ -5583,6 +5695,118 @@
     "closure": {
       "fromPath": "/nix/store/s1qn8zx84hc2kzk6paq78anrpwcgsniz-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
       "toPath": "/nix/store/lsz7g27zdwawpk728c5i1kh4jd1qrywq-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-smash-server-exe-cardano-smash-server",
+    "system": "x86_64-linux",
+    "exeName": "cardano-smash-server"
+  },
+  "github:IntersectMBO/cardano-db-sync/380a3139dd5c822968b8211ce3a18e6dbf6df6b3#packages.x86_64-linux.cardano-db-sync": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-db-sync",
+    "version": "sancho-1-0-0",
+    "commit": "380a3139dd5c822968b8211ce3a18e6dbf6df6b3",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/8g0jm7ryhjlidxipgps7491mrlfgs8fw-source/overlays/haskell-nix-extra/default.nix:55",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/dskv5qvl1v1lscx2cgmn66d8i7wr6qvi-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
+    "closure": {
+      "fromPath": "/nix/store/dskv5qvl1v1lscx2cgmn66d8i7wr6qvi-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
+      "toPath": "/nix/store/55n2vgvd90qmajbjdw1d47rdrb823wxr-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-db-sync-exe-cardano-db-sync",
+    "system": "x86_64-linux",
+    "exeName": "cardano-db-sync"
+  },
+  "github:IntersectMBO/cardano-db-sync/380a3139dd5c822968b8211ce3a18e6dbf6df6b3#packages.x86_64-linux.cardano-db-tool": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-db-tool",
+    "version": "sancho-1-0-0",
+    "commit": "380a3139dd5c822968b8211ce3a18e6dbf6df6b3",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/8g0jm7ryhjlidxipgps7491mrlfgs8fw-source/overlays/haskell-nix-extra/default.nix:55",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/v70grdcdxh99sc149q647h388vf01xy5-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
+    "closure": {
+      "fromPath": "/nix/store/v70grdcdxh99sc149q647h388vf01xy5-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
+      "toPath": "/nix/store/r5ahgk4yqna0sbcflfqrzhz58yq6ngvb-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-db-tool-exe-cardano-db-tool",
+    "system": "x86_64-linux",
+    "exeName": "cardano-db-tool"
+  },
+  "github:IntersectMBO/cardano-db-sync/380a3139dd5c822968b8211ce3a18e6dbf6df6b3#packages.x86_64-linux.cardano-smash-server": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-smash-server",
+    "version": "sancho-1-0-0",
+    "commit": "380a3139dd5c822968b8211ce3a18e6dbf6df6b3",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/8g0jm7ryhjlidxipgps7491mrlfgs8fw-source/overlays/haskell-nix-extra/default.nix:55",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/yymiwkqqrxk645w51dv0g2w8ig1mjv6a-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+    "closure": {
+      "fromPath": "/nix/store/yymiwkqqrxk645w51dv0g2w8ig1mjv6a-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "toPath": "/nix/store/v2mqxhbzf42m42mffg2cp4pw71jlj2vx-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-smash-server-exe-cardano-smash-server",
+    "system": "x86_64-linux",
+    "exeName": "cardano-smash-server"
+  },
+  "github:IntersectMBO/cardano-db-sync/380a3139dd5c822968b8211ce3a18e6dbf6df6b3#packages.x86_64-linux.cardano-smash-server-no-basic-auth": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-smash-server-no-basic-auth",
+    "version": "sancho-1-0-0",
+    "commit": "380a3139dd5c822968b8211ce3a18e6dbf6df6b3",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/8g0jm7ryhjlidxipgps7491mrlfgs8fw-source/overlays/haskell-nix-extra/default.nix:55",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/14i2hn3nmhbzgsjd5yi8r5qpdq7k0hdp-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+    "closure": {
+      "fromPath": "/nix/store/14i2hn3nmhbzgsjd5yi8r5qpdq7k0hdp-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "toPath": "/nix/store/axf0nykqmr4qxwr97ccnm6d4a5cri480-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
       "fromStore": "https://cache.iog.io"
     },
     "pname": "cardano-smash-server-exe-cardano-smash-server",
@@ -6861,6 +7085,118 @@
     "system": "x86_64-linux",
     "exeName": "cardano-smash-server"
   },
+  "github:IntersectMBO/cardano-db-sync/4a1e378febaacda67aae410deee6812e2a1e3d8e#packages.x86_64-linux.\"cardano-db-sync:exe:cardano-db-sync\"": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.\"cardano-db-sync:exe:cardano-db-sync\"",
+    "version": "sancho-4.1.0",
+    "commit": "4a1e378febaacda67aae410deee6812e2a1e3d8e",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-db-sync-exe-cardano-db-sync-13.2.0.1",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/44dywz387yxs2cqba5mmk6ab40phnjsl-source/overlays/haskell-nix-extra/default.nix:55",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/9kp1lzmh9qqck7zyhjn5ry4lhmgns6jr-cardano-db-sync-exe-cardano-db-sync-13.2.0.1",
+    "closure": {
+      "fromPath": "/nix/store/9kp1lzmh9qqck7zyhjn5ry4lhmgns6jr-cardano-db-sync-exe-cardano-db-sync-13.2.0.1",
+      "toPath": "/nix/store/mdya0vc1iai932lzfv77cywl2vm0g6sm-cardano-db-sync-exe-cardano-db-sync-13.2.0.1",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-db-sync-exe-cardano-db-sync",
+    "system": "x86_64-linux",
+    "exeName": "cardano-db-sync"
+  },
+  "github:IntersectMBO/cardano-db-sync/4a1e378febaacda67aae410deee6812e2a1e3d8e#packages.x86_64-linux.\"cardano-db-tool:exe:cardano-db-tool\"": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.\"cardano-db-tool:exe:cardano-db-tool\"",
+    "version": "sancho-4.1.0",
+    "commit": "4a1e378febaacda67aae410deee6812e2a1e3d8e",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-db-tool-exe-cardano-db-tool-13.2.0.1",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/44dywz387yxs2cqba5mmk6ab40phnjsl-source/overlays/haskell-nix-extra/default.nix:55",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/ha645bbbz2l3gaicaf5zv8n5wz6pfgn8-cardano-db-tool-exe-cardano-db-tool-13.2.0.1",
+    "closure": {
+      "fromPath": "/nix/store/ha645bbbz2l3gaicaf5zv8n5wz6pfgn8-cardano-db-tool-exe-cardano-db-tool-13.2.0.1",
+      "toPath": "/nix/store/4knbx4d8l2sfch2y7vd98cdkcwxfz15m-cardano-db-tool-exe-cardano-db-tool-13.2.0.1",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-db-tool-exe-cardano-db-tool",
+    "system": "x86_64-linux",
+    "exeName": "cardano-db-tool"
+  },
+  "github:IntersectMBO/cardano-db-sync/4a1e378febaacda67aae410deee6812e2a1e3d8e#packages.x86_64-linux.\"cardano-smash-server:exe:cardano-smash-server\"": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.\"cardano-smash-server:exe:cardano-smash-server\"",
+    "version": "sancho-4.1.0",
+    "commit": "4a1e378febaacda67aae410deee6812e2a1e3d8e",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-smash-server-exe-cardano-smash-server-13.2.0.1",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/44dywz387yxs2cqba5mmk6ab40phnjsl-source/overlays/haskell-nix-extra/default.nix:55",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/mggl5a31m2kx1x698v7v75sgcqa72sys-cardano-smash-server-exe-cardano-smash-server-13.2.0.1",
+    "closure": {
+      "fromPath": "/nix/store/mggl5a31m2kx1x698v7v75sgcqa72sys-cardano-smash-server-exe-cardano-smash-server-13.2.0.1",
+      "toPath": "/nix/store/ipfcj22vj7ljqyrnm4qwmagw0fnv4kir-cardano-smash-server-exe-cardano-smash-server-13.2.0.1",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-smash-server-exe-cardano-smash-server",
+    "system": "x86_64-linux",
+    "exeName": "cardano-smash-server"
+  },
+  "github:IntersectMBO/cardano-db-sync/4a1e378febaacda67aae410deee6812e2a1e3d8e#packages.x86_64-linux.cardano-smash-server-no-basic-auth": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-smash-server-no-basic-auth",
+    "version": "sancho-4.1.0",
+    "commit": "4a1e378febaacda67aae410deee6812e2a1e3d8e",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-smash-server-exe-cardano-smash-server-13.2.0.1",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/44dywz387yxs2cqba5mmk6ab40phnjsl-source/overlays/haskell-nix-extra/default.nix:55",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/ycz1im07y07y05mh4yn9lhafzvyj11ba-cardano-smash-server-exe-cardano-smash-server-13.2.0.1",
+    "closure": {
+      "fromPath": "/nix/store/ycz1im07y07y05mh4yn9lhafzvyj11ba-cardano-smash-server-exe-cardano-smash-server-13.2.0.1",
+      "toPath": "/nix/store/66hj95g6m35dk5j9631nix6zhkpwc3j7-cardano-smash-server-exe-cardano-smash-server-13.2.0.1",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-smash-server-exe-cardano-smash-server",
+    "system": "x86_64-linux",
+    "exeName": "cardano-smash-server"
+  },
   "github:IntersectMBO/cardano-db-sync/5eff9a0df135f903a803762d54bde5882aefa42e#packages.x86_64-linux.\"cardano-db-sync:exe:cardano-db-sync\"": {
     "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.\"cardano-db-sync:exe:cardano-db-sync\"",
     "version": "10.0.0",
@@ -7212,6 +7548,230 @@
     "pname": "cardano-db-tool-exe-cardano-db-tool",
     "system": "x86_64-linux",
     "exeName": "cardano-db-tool"
+  },
+  "github:IntersectMBO/cardano-db-sync/68a1ab0adada96bf72fb7558d12850441ed4b749#packages.x86_64-linux.cardano-db-sync": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-db-sync",
+    "version": "sancho-2-1-0",
+    "commit": "68a1ab0adada96bf72fb7558d12850441ed4b749",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/yziw234fh9lhmji1919sa84wjny5vdrs-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
+    "closure": {
+      "fromPath": "/nix/store/yziw234fh9lhmji1919sa84wjny5vdrs-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
+      "toPath": "/nix/store/gizb069wp7y2py017pv5ym8vx2mksyb6-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-db-sync-exe-cardano-db-sync",
+    "system": "x86_64-linux",
+    "exeName": "cardano-db-sync"
+  },
+  "github:IntersectMBO/cardano-db-sync/68a1ab0adada96bf72fb7558d12850441ed4b749#packages.x86_64-linux.cardano-db-tool": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-db-tool",
+    "version": "sancho-2-1-0",
+    "commit": "68a1ab0adada96bf72fb7558d12850441ed4b749",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/710vhwf18a28y33ma970q4vlg0i2lfrm-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
+    "closure": {
+      "fromPath": "/nix/store/710vhwf18a28y33ma970q4vlg0i2lfrm-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
+      "toPath": "/nix/store/s9nh2djvmk9v3xckawcybkx8bx7j4nm9-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-db-tool-exe-cardano-db-tool",
+    "system": "x86_64-linux",
+    "exeName": "cardano-db-tool"
+  },
+  "github:IntersectMBO/cardano-db-sync/68a1ab0adada96bf72fb7558d12850441ed4b749#packages.x86_64-linux.cardano-smash-server": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-smash-server",
+    "version": "sancho-2-1-0",
+    "commit": "68a1ab0adada96bf72fb7558d12850441ed4b749",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/aa928y1vw9csbm9gz7j18srzpccajfzv-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+    "closure": {
+      "fromPath": "/nix/store/aa928y1vw9csbm9gz7j18srzpccajfzv-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "toPath": "/nix/store/nzzw5wcdzgkscyy15vg0yr6hg2xw9mln-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-smash-server-exe-cardano-smash-server",
+    "system": "x86_64-linux",
+    "exeName": "cardano-smash-server"
+  },
+  "github:IntersectMBO/cardano-db-sync/68a1ab0adada96bf72fb7558d12850441ed4b749#packages.x86_64-linux.cardano-smash-server-no-basic-auth": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-smash-server-no-basic-auth",
+    "version": "sancho-2-1-0",
+    "commit": "68a1ab0adada96bf72fb7558d12850441ed4b749",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/s12wgb59nicm4gipr36kbx1ggi9klmc9-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+    "closure": {
+      "fromPath": "/nix/store/s12wgb59nicm4gipr36kbx1ggi9klmc9-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "toPath": "/nix/store/h5djyj0a9fh33l2a91dzm9r81hdwyviv-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-smash-server-exe-cardano-smash-server",
+    "system": "x86_64-linux",
+    "exeName": "cardano-smash-server"
+  },
+  "github:IntersectMBO/cardano-db-sync/738c5988f24127733e5a6c98e40410604b5a16c9#packages.x86_64-linux.\"cardano-db-sync:exe:cardano-db-sync\"": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.\"cardano-db-sync:exe:cardano-db-sync\"",
+    "version": "sancho-3-0-0",
+    "commit": "738c5988f24127733e5a6c98e40410604b5a16c9",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-db-sync-exe-cardano-db-sync-13.2.0.0",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/4q1kj9w3iz9pw4l26jjq0bwvlqg4x4am-source/overlays/haskell-nix-extra/default.nix:55",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/j2bd4fwgxkx6r8lr8fb469556d16bybp-cardano-db-sync-exe-cardano-db-sync-13.2.0.0",
+    "closure": {
+      "fromPath": "/nix/store/j2bd4fwgxkx6r8lr8fb469556d16bybp-cardano-db-sync-exe-cardano-db-sync-13.2.0.0",
+      "toPath": "/nix/store/0yql3h3k2h066lf8bfr274adbdzfnw0h-cardano-db-sync-exe-cardano-db-sync-13.2.0.0",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-db-sync-exe-cardano-db-sync",
+    "system": "x86_64-linux",
+    "exeName": "cardano-db-sync"
+  },
+  "github:IntersectMBO/cardano-db-sync/738c5988f24127733e5a6c98e40410604b5a16c9#packages.x86_64-linux.\"cardano-db-tool:exe:cardano-db-tool\"": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.\"cardano-db-tool:exe:cardano-db-tool\"",
+    "version": "sancho-3-0-0",
+    "commit": "738c5988f24127733e5a6c98e40410604b5a16c9",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-db-tool-exe-cardano-db-tool-13.2.0.0",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/4q1kj9w3iz9pw4l26jjq0bwvlqg4x4am-source/overlays/haskell-nix-extra/default.nix:55",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/0xa8na6f11931i7cm77vyvxf4jvklnld-cardano-db-tool-exe-cardano-db-tool-13.2.0.0",
+    "closure": {
+      "fromPath": "/nix/store/0xa8na6f11931i7cm77vyvxf4jvklnld-cardano-db-tool-exe-cardano-db-tool-13.2.0.0",
+      "toPath": "/nix/store/c691jv8jw0wmpkikvgb3w3lvz4b5rzrz-cardano-db-tool-exe-cardano-db-tool-13.2.0.0",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-db-tool-exe-cardano-db-tool",
+    "system": "x86_64-linux",
+    "exeName": "cardano-db-tool"
+  },
+  "github:IntersectMBO/cardano-db-sync/738c5988f24127733e5a6c98e40410604b5a16c9#packages.x86_64-linux.\"cardano-smash-server:exe:cardano-smash-server\"": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.\"cardano-smash-server:exe:cardano-smash-server\"",
+    "version": "sancho-3-0-0",
+    "commit": "738c5988f24127733e5a6c98e40410604b5a16c9",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/4q1kj9w3iz9pw4l26jjq0bwvlqg4x4am-source/overlays/haskell-nix-extra/default.nix:55",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/hbbrf5pigg7nlmmmjagaz4p0xjmww70h-cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
+    "closure": {
+      "fromPath": "/nix/store/hbbrf5pigg7nlmmmjagaz4p0xjmww70h-cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
+      "toPath": "/nix/store/j3ndm6hiz47rnx11739xyy7qgbyb0850-cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-smash-server-exe-cardano-smash-server",
+    "system": "x86_64-linux",
+    "exeName": "cardano-smash-server"
+  },
+  "github:IntersectMBO/cardano-db-sync/738c5988f24127733e5a6c98e40410604b5a16c9#packages.x86_64-linux.cardano-smash-server-no-basic-auth": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-smash-server-no-basic-auth",
+    "version": "sancho-3-0-0",
+    "commit": "738c5988f24127733e5a6c98e40410604b5a16c9",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/4q1kj9w3iz9pw4l26jjq0bwvlqg4x4am-source/overlays/haskell-nix-extra/default.nix:55",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/zvi486y5sdyhf25dbyl1ha3xi4hhv0sr-cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
+    "closure": {
+      "fromPath": "/nix/store/zvi486y5sdyhf25dbyl1ha3xi4hhv0sr-cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
+      "toPath": "/nix/store/1kciaalbpd8v9g29xpani5677fq7gdk3-cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-smash-server-exe-cardano-smash-server",
+    "system": "x86_64-linux",
+    "exeName": "cardano-smash-server"
   },
   "github:IntersectMBO/cardano-db-sync/790dc0ed32f92816a477d4229060fca2f8533479#packages.x86_64-linux.\"cardano-db-sync:exe:cardano-db-sync\"": {
     "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.\"cardano-db-sync:exe:cardano-db-sync\"",
@@ -7677,224 +8237,112 @@
     "system": "x86_64-linux",
     "exeName": "cardano-db-tool"
   },
-  "github:IntersectMBO/cardano-db-sync/8cfc3410ac778daf4aa54d272065b5093dea3054#packages.x86_64-linux.cardano-db-sync": {
-    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-db-sync",
-    "version": "sancho-1-1-0",
-    "commit": "8cfc3410ac778daf4aa54d272065b5093dea3054",
+  "github:IntersectMBO/cardano-db-sync/8d4351000e1f85f43aebe0c4a59a572b4291699b#packages.x86_64-linux.\"cardano-db-sync:exe:cardano-db-sync\"": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.\"cardano-db-sync:exe:cardano-db-sync\"",
+    "version": "sancho-4-0-0",
+    "commit": "8d4351000e1f85f43aebe0c4a59a572b4291699b",
     "org_name": "input-output-hk",
     "repo_name": "cardano-db-sync",
     "meta": {
       "available": true,
       "broken": false,
       "insecure": false,
-      "name": "cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
+      "name": "cardano-db-sync-exe-cardano-db-sync-13.2.0.0",
       "outputsToInstall": [
         "out"
       ],
-      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
+      "position": "/nix/store/4q1kj9w3iz9pw4l26jjq0bwvlqg4x4am-source/overlays/haskell-nix-extra/default.nix:55",
       "unfree": false,
       "unsupported": false
     },
-    "output": "/nix/store/q9k9hhan0rfg4gyr09bivq49cqyigrwb-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
+    "output": "/nix/store/hjlmcj93mxvl1wqfsmac1pj9rfk106hw-cardano-db-sync-exe-cardano-db-sync-13.2.0.0",
     "closure": {
-      "fromPath": "/nix/store/q9k9hhan0rfg4gyr09bivq49cqyigrwb-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
-      "toPath": "/nix/store/49897q2da4rwwkasxijd4w79hsp0hb7w-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
+      "fromPath": "/nix/store/hjlmcj93mxvl1wqfsmac1pj9rfk106hw-cardano-db-sync-exe-cardano-db-sync-13.2.0.0",
+      "toPath": "/nix/store/igqn0v7v9s5m981jclcwbbh42cw81jkl-cardano-db-sync-exe-cardano-db-sync-13.2.0.0",
       "fromStore": "https://cache.iog.io"
     },
     "pname": "cardano-db-sync-exe-cardano-db-sync",
     "system": "x86_64-linux",
     "exeName": "cardano-db-sync"
   },
-  "github:IntersectMBO/cardano-db-sync/8cfc3410ac778daf4aa54d272065b5093dea3054#packages.x86_64-linux.cardano-db-tool": {
-    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-db-tool",
-    "version": "sancho-1-1-0",
-    "commit": "8cfc3410ac778daf4aa54d272065b5093dea3054",
+  "github:IntersectMBO/cardano-db-sync/8d4351000e1f85f43aebe0c4a59a572b4291699b#packages.x86_64-linux.\"cardano-db-tool:exe:cardano-db-tool\"": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.\"cardano-db-tool:exe:cardano-db-tool\"",
+    "version": "sancho-4-0-0",
+    "commit": "8d4351000e1f85f43aebe0c4a59a572b4291699b",
     "org_name": "input-output-hk",
     "repo_name": "cardano-db-sync",
     "meta": {
       "available": true,
       "broken": false,
       "insecure": false,
-      "name": "cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
+      "name": "cardano-db-tool-exe-cardano-db-tool-13.2.0.0",
       "outputsToInstall": [
         "out"
       ],
-      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
+      "position": "/nix/store/4q1kj9w3iz9pw4l26jjq0bwvlqg4x4am-source/overlays/haskell-nix-extra/default.nix:55",
       "unfree": false,
       "unsupported": false
     },
-    "output": "/nix/store/bins39aql5g2k7zsrqssmi3sysrwd7qk-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
+    "output": "/nix/store/bxsglqxq9kajk32m2ivqi363697052cl-cardano-db-tool-exe-cardano-db-tool-13.2.0.0",
     "closure": {
-      "fromPath": "/nix/store/bins39aql5g2k7zsrqssmi3sysrwd7qk-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
-      "toPath": "/nix/store/axsds765ax7crw1vfjhbqbhvph18mzp0-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
+      "fromPath": "/nix/store/bxsglqxq9kajk32m2ivqi363697052cl-cardano-db-tool-exe-cardano-db-tool-13.2.0.0",
+      "toPath": "/nix/store/y8wckl7ay8fgcb4si9q9f18dvyiv8abv-cardano-db-tool-exe-cardano-db-tool-13.2.0.0",
       "fromStore": "https://cache.iog.io"
     },
     "pname": "cardano-db-tool-exe-cardano-db-tool",
     "system": "x86_64-linux",
     "exeName": "cardano-db-tool"
   },
-  "github:IntersectMBO/cardano-db-sync/8cfc3410ac778daf4aa54d272065b5093dea3054#packages.x86_64-linux.cardano-smash-server": {
-    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-smash-server",
-    "version": "sancho-1-1-0",
-    "commit": "8cfc3410ac778daf4aa54d272065b5093dea3054",
+  "github:IntersectMBO/cardano-db-sync/8d4351000e1f85f43aebe0c4a59a572b4291699b#packages.x86_64-linux.\"cardano-smash-server:exe:cardano-smash-server\"": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.\"cardano-smash-server:exe:cardano-smash-server\"",
+    "version": "sancho-4-0-0",
+    "commit": "8d4351000e1f85f43aebe0c4a59a572b4291699b",
     "org_name": "input-output-hk",
     "repo_name": "cardano-db-sync",
     "meta": {
       "available": true,
       "broken": false,
       "insecure": false,
-      "name": "cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "name": "cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
       "outputsToInstall": [
         "out"
       ],
-      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
+      "position": "/nix/store/4q1kj9w3iz9pw4l26jjq0bwvlqg4x4am-source/overlays/haskell-nix-extra/default.nix:55",
       "unfree": false,
       "unsupported": false
     },
-    "output": "/nix/store/3nv0s94mkvvc226aj2hw4iq6wzcj907w-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+    "output": "/nix/store/fjhlxri0c1hy60wp90fzpk3fz1rf749x-cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
     "closure": {
-      "fromPath": "/nix/store/3nv0s94mkvvc226aj2hw4iq6wzcj907w-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
-      "toPath": "/nix/store/ajgs37s4ksw690il6vjzamar3fwj2jic-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "fromPath": "/nix/store/fjhlxri0c1hy60wp90fzpk3fz1rf749x-cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
+      "toPath": "/nix/store/vrk8dn9yjbbw2jnm76zaw0418idibi7v-cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
       "fromStore": "https://cache.iog.io"
     },
     "pname": "cardano-smash-server-exe-cardano-smash-server",
     "system": "x86_64-linux",
     "exeName": "cardano-smash-server"
   },
-  "github:IntersectMBO/cardano-db-sync/8cfc3410ac778daf4aa54d272065b5093dea3054#packages.x86_64-linux.cardano-smash-server-no-basic-auth": {
+  "github:IntersectMBO/cardano-db-sync/8d4351000e1f85f43aebe0c4a59a572b4291699b#packages.x86_64-linux.cardano-smash-server-no-basic-auth": {
     "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-smash-server-no-basic-auth",
-    "version": "sancho-1-1-0",
-    "commit": "8cfc3410ac778daf4aa54d272065b5093dea3054",
+    "version": "sancho-4-0-0",
+    "commit": "8d4351000e1f85f43aebe0c4a59a572b4291699b",
     "org_name": "input-output-hk",
     "repo_name": "cardano-db-sync",
     "meta": {
       "available": true,
       "broken": false,
       "insecure": false,
-      "name": "cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "name": "cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
       "outputsToInstall": [
         "out"
       ],
-      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
+      "position": "/nix/store/4q1kj9w3iz9pw4l26jjq0bwvlqg4x4am-source/overlays/haskell-nix-extra/default.nix:55",
       "unfree": false,
       "unsupported": false
     },
-    "output": "/nix/store/fhagskqwrdsqma3n12y2a078k9bzqsiv-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+    "output": "/nix/store/s0l38g0i9hnafxmkfnkkiz2mbabv2hpg-cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
     "closure": {
-      "fromPath": "/nix/store/fhagskqwrdsqma3n12y2a078k9bzqsiv-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
-      "toPath": "/nix/store/jhr4d5g9qsikw63qn3q0yf8fb3afvsjs-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
-      "fromStore": "https://cache.iog.io"
-    },
-    "pname": "cardano-smash-server-exe-cardano-smash-server",
-    "system": "x86_64-linux",
-    "exeName": "cardano-smash-server"
-  },
-  "github:IntersectMBO/cardano-db-sync/8eb04eeb7016ff19a82d32792fbbaaa884a1be68#packages.x86_64-linux.cardano-db-sync": {
-    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-db-sync",
-    "version": "sancho-2-0-0",
-    "commit": "8eb04eeb7016ff19a82d32792fbbaaa884a1be68",
-    "org_name": "input-output-hk",
-    "repo_name": "cardano-db-sync",
-    "meta": {
-      "available": true,
-      "broken": false,
-      "insecure": false,
-      "name": "cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
-      "outputsToInstall": [
-        "out"
-      ],
-      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
-      "unfree": false,
-      "unsupported": false
-    },
-    "output": "/nix/store/szln421nl8smjc4nd97s41zydrspbpl8-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
-    "closure": {
-      "fromPath": "/nix/store/szln421nl8smjc4nd97s41zydrspbpl8-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
-      "toPath": "/nix/store/lz68dgv4d2602prrr1mib4i22fa1m4iw-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
-      "fromStore": "https://cache.iog.io"
-    },
-    "pname": "cardano-db-sync-exe-cardano-db-sync",
-    "system": "x86_64-linux",
-    "exeName": "cardano-db-sync"
-  },
-  "github:IntersectMBO/cardano-db-sync/8eb04eeb7016ff19a82d32792fbbaaa884a1be68#packages.x86_64-linux.cardano-db-tool": {
-    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-db-tool",
-    "version": "sancho-2-0-0",
-    "commit": "8eb04eeb7016ff19a82d32792fbbaaa884a1be68",
-    "org_name": "input-output-hk",
-    "repo_name": "cardano-db-sync",
-    "meta": {
-      "available": true,
-      "broken": false,
-      "insecure": false,
-      "name": "cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
-      "outputsToInstall": [
-        "out"
-      ],
-      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
-      "unfree": false,
-      "unsupported": false
-    },
-    "output": "/nix/store/pb0iwiqxg53wgw58zi6wkg4gz2a5q6sa-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
-    "closure": {
-      "fromPath": "/nix/store/pb0iwiqxg53wgw58zi6wkg4gz2a5q6sa-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
-      "toPath": "/nix/store/c2mfb0308vm7j1rkxyqb6m5rvzcld44y-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
-      "fromStore": "https://cache.iog.io"
-    },
-    "pname": "cardano-db-tool-exe-cardano-db-tool",
-    "system": "x86_64-linux",
-    "exeName": "cardano-db-tool"
-  },
-  "github:IntersectMBO/cardano-db-sync/8eb04eeb7016ff19a82d32792fbbaaa884a1be68#packages.x86_64-linux.cardano-smash-server": {
-    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-smash-server",
-    "version": "sancho-2-0-0",
-    "commit": "8eb04eeb7016ff19a82d32792fbbaaa884a1be68",
-    "org_name": "input-output-hk",
-    "repo_name": "cardano-db-sync",
-    "meta": {
-      "available": true,
-      "broken": false,
-      "insecure": false,
-      "name": "cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
-      "outputsToInstall": [
-        "out"
-      ],
-      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
-      "unfree": false,
-      "unsupported": false
-    },
-    "output": "/nix/store/m5ar3hvwymi814ba0z95f2kggz776vg4-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
-    "closure": {
-      "fromPath": "/nix/store/m5ar3hvwymi814ba0z95f2kggz776vg4-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
-      "toPath": "/nix/store/wj055l803aq2fc6c628b608rms2mxjwa-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
-      "fromStore": "https://cache.iog.io"
-    },
-    "pname": "cardano-smash-server-exe-cardano-smash-server",
-    "system": "x86_64-linux",
-    "exeName": "cardano-smash-server"
-  },
-  "github:IntersectMBO/cardano-db-sync/8eb04eeb7016ff19a82d32792fbbaaa884a1be68#packages.x86_64-linux.cardano-smash-server-no-basic-auth": {
-    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-smash-server-no-basic-auth",
-    "version": "sancho-2-0-0",
-    "commit": "8eb04eeb7016ff19a82d32792fbbaaa884a1be68",
-    "org_name": "input-output-hk",
-    "repo_name": "cardano-db-sync",
-    "meta": {
-      "available": true,
-      "broken": false,
-      "insecure": false,
-      "name": "cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
-      "outputsToInstall": [
-        "out"
-      ],
-      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
-      "unfree": false,
-      "unsupported": false
-    },
-    "output": "/nix/store/68n6xglaha3i7qmwz93y4b1d84dp428f-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
-    "closure": {
-      "fromPath": "/nix/store/68n6xglaha3i7qmwz93y4b1d84dp428f-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
-      "toPath": "/nix/store/wfyyyig7yhw4zn3p32bs93xqgxws3333-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "fromPath": "/nix/store/s0l38g0i9hnafxmkfnkkiz2mbabv2hpg-cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
+      "toPath": "/nix/store/7c04c1w0lgxzi9kp8hzr5qmi77v31hys-cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
       "fromStore": "https://cache.iog.io"
     },
     "pname": "cardano-smash-server-exe-cardano-smash-server",
@@ -9053,118 +9501,6 @@
     "system": "x86_64-linux",
     "exeName": "cardano-smash-server"
   },
-  "github:IntersectMBO/cardano-db-sync/acc120f3168f3818579515264b2f2a792370b7d5#packages.x86_64-linux.cardano-db-sync": {
-    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-db-sync",
-    "version": "sancho-2-0-1",
-    "commit": "acc120f3168f3818579515264b2f2a792370b7d5",
-    "org_name": "input-output-hk",
-    "repo_name": "cardano-db-sync",
-    "meta": {
-      "available": true,
-      "broken": false,
-      "insecure": false,
-      "name": "cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
-      "outputsToInstall": [
-        "out"
-      ],
-      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
-      "unfree": false,
-      "unsupported": false
-    },
-    "output": "/nix/store/k0k3zflvxk7bmgvk58p838napdgz07c9-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
-    "closure": {
-      "fromPath": "/nix/store/k0k3zflvxk7bmgvk58p838napdgz07c9-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
-      "toPath": "/nix/store/h8vy875nwk5rv5kanjcb64xbhfkqp296-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
-      "fromStore": "https://cache.iog.io"
-    },
-    "pname": "cardano-db-sync-exe-cardano-db-sync",
-    "system": "x86_64-linux",
-    "exeName": "cardano-db-sync"
-  },
-  "github:IntersectMBO/cardano-db-sync/acc120f3168f3818579515264b2f2a792370b7d5#packages.x86_64-linux.cardano-db-tool": {
-    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-db-tool",
-    "version": "sancho-2-0-1",
-    "commit": "acc120f3168f3818579515264b2f2a792370b7d5",
-    "org_name": "input-output-hk",
-    "repo_name": "cardano-db-sync",
-    "meta": {
-      "available": true,
-      "broken": false,
-      "insecure": false,
-      "name": "cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
-      "outputsToInstall": [
-        "out"
-      ],
-      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
-      "unfree": false,
-      "unsupported": false
-    },
-    "output": "/nix/store/zj2j86a0m1w9n2lbryb4rcyvdvd8pl63-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
-    "closure": {
-      "fromPath": "/nix/store/zj2j86a0m1w9n2lbryb4rcyvdvd8pl63-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
-      "toPath": "/nix/store/i9zywp7j5x3c3j5fnhd787gqws2xikkf-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
-      "fromStore": "https://cache.iog.io"
-    },
-    "pname": "cardano-db-tool-exe-cardano-db-tool",
-    "system": "x86_64-linux",
-    "exeName": "cardano-db-tool"
-  },
-  "github:IntersectMBO/cardano-db-sync/acc120f3168f3818579515264b2f2a792370b7d5#packages.x86_64-linux.cardano-smash-server": {
-    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-smash-server",
-    "version": "sancho-2-0-1",
-    "commit": "acc120f3168f3818579515264b2f2a792370b7d5",
-    "org_name": "input-output-hk",
-    "repo_name": "cardano-db-sync",
-    "meta": {
-      "available": true,
-      "broken": false,
-      "insecure": false,
-      "name": "cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
-      "outputsToInstall": [
-        "out"
-      ],
-      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
-      "unfree": false,
-      "unsupported": false
-    },
-    "output": "/nix/store/dvn6kmyxpbsg5ng30zp6mjdkfvymsyai-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
-    "closure": {
-      "fromPath": "/nix/store/dvn6kmyxpbsg5ng30zp6mjdkfvymsyai-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
-      "toPath": "/nix/store/097rhd5r0z9p0pxamgpmx3547j9vysf6-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
-      "fromStore": "https://cache.iog.io"
-    },
-    "pname": "cardano-smash-server-exe-cardano-smash-server",
-    "system": "x86_64-linux",
-    "exeName": "cardano-smash-server"
-  },
-  "github:IntersectMBO/cardano-db-sync/acc120f3168f3818579515264b2f2a792370b7d5#packages.x86_64-linux.cardano-smash-server-no-basic-auth": {
-    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-smash-server-no-basic-auth",
-    "version": "sancho-2-0-1",
-    "commit": "acc120f3168f3818579515264b2f2a792370b7d5",
-    "org_name": "input-output-hk",
-    "repo_name": "cardano-db-sync",
-    "meta": {
-      "available": true,
-      "broken": false,
-      "insecure": false,
-      "name": "cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
-      "outputsToInstall": [
-        "out"
-      ],
-      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
-      "unfree": false,
-      "unsupported": false
-    },
-    "output": "/nix/store/g6ip58gkqg8iiw1jba9bd5f0crhmhinj-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
-    "closure": {
-      "fromPath": "/nix/store/g6ip58gkqg8iiw1jba9bd5f0crhmhinj-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
-      "toPath": "/nix/store/kira6nzxkzyiijczw1b4gm1d5kyg6z2p-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
-      "fromStore": "https://cache.iog.io"
-    },
-    "pname": "cardano-smash-server-exe-cardano-smash-server",
-    "system": "x86_64-linux",
-    "exeName": "cardano-smash-server"
-  },
   "github:IntersectMBO/cardano-db-sync/b3519b7e5380476c5ed0126c89ccba1355a2fc12#packages.x86_64-linux.\"cardano-db-sync:exe:cardano-db-sync\"": {
     "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.\"cardano-db-sync:exe:cardano-db-sync\"",
     "version": "sancho-2-3-0",
@@ -9277,6 +9613,118 @@
     "system": "x86_64-linux",
     "exeName": "cardano-smash-server"
   },
+  "github:IntersectMBO/cardano-db-sync/b44eb735fe64fe4e8079935df722d0a32a41c2a4#packages.x86_64-linux.cardano-db-sync": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-db-sync",
+    "version": "sancho-1-1-0",
+    "commit": "b44eb735fe64fe4e8079935df722d0a32a41c2a4",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/wlc0x969mqhmzq3dkdl5hvrnrwh105n9-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
+    "closure": {
+      "fromPath": "/nix/store/wlc0x969mqhmzq3dkdl5hvrnrwh105n9-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
+      "toPath": "/nix/store/gk0ncjwk3iiicbz2bsrwrxdp6mniafq7-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-db-sync-exe-cardano-db-sync",
+    "system": "x86_64-linux",
+    "exeName": "cardano-db-sync"
+  },
+  "github:IntersectMBO/cardano-db-sync/b44eb735fe64fe4e8079935df722d0a32a41c2a4#packages.x86_64-linux.cardano-db-tool": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-db-tool",
+    "version": "sancho-1-1-0",
+    "commit": "b44eb735fe64fe4e8079935df722d0a32a41c2a4",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/y22mp5f67qdyhqws5w1kfj934x8hg89j-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
+    "closure": {
+      "fromPath": "/nix/store/y22mp5f67qdyhqws5w1kfj934x8hg89j-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
+      "toPath": "/nix/store/mkmlibalw34b99bv4yfwhaxiw9vb3wa0-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-db-tool-exe-cardano-db-tool",
+    "system": "x86_64-linux",
+    "exeName": "cardano-db-tool"
+  },
+  "github:IntersectMBO/cardano-db-sync/b44eb735fe64fe4e8079935df722d0a32a41c2a4#packages.x86_64-linux.cardano-smash-server": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-smash-server",
+    "version": "sancho-1-1-0",
+    "commit": "b44eb735fe64fe4e8079935df722d0a32a41c2a4",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/az2dz9flq58sxabxpp1zjalvjcg25mxz-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+    "closure": {
+      "fromPath": "/nix/store/az2dz9flq58sxabxpp1zjalvjcg25mxz-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "toPath": "/nix/store/isgapvqs534gl0qy5pdcvyck4f4qf016-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-smash-server-exe-cardano-smash-server",
+    "system": "x86_64-linux",
+    "exeName": "cardano-smash-server"
+  },
+  "github:IntersectMBO/cardano-db-sync/b44eb735fe64fe4e8079935df722d0a32a41c2a4#packages.x86_64-linux.cardano-smash-server-no-basic-auth": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-smash-server-no-basic-auth",
+    "version": "sancho-1-1-0",
+    "commit": "b44eb735fe64fe4e8079935df722d0a32a41c2a4",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/9lcc0rmpizgb8633ncvhz35nxhb09wf7-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+    "closure": {
+      "fromPath": "/nix/store/9lcc0rmpizgb8633ncvhz35nxhb09wf7-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "toPath": "/nix/store/bjbx6nfr4brvy84m8bskgci35qyl5kwc-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-smash-server-exe-cardano-smash-server",
+    "system": "x86_64-linux",
+    "exeName": "cardano-smash-server"
+  },
   "github:IntersectMBO/cardano-db-sync/ba77cf22ae86974482e4eabc0dadb8af5f2e891a#packages.x86_64-linux.\"cardano-db-sync:exe:cardano-db-sync\"": {
     "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.\"cardano-db-sync:exe:cardano-db-sync\"",
     "version": "13.2.0.1",
@@ -9383,230 +9831,6 @@
     "closure": {
       "fromPath": "/nix/store/fwcgfb8lz7wv4xs31gwzw86m8vkhqzi0-cardano-smash-server-exe-cardano-smash-server-13.2.0.1",
       "toPath": "/nix/store/m8259pyb0kkvy7w2yq9x66lsqy5ala96-cardano-smash-server-exe-cardano-smash-server-13.2.0.1",
-      "fromStore": "https://cache.iog.io"
-    },
-    "pname": "cardano-smash-server-exe-cardano-smash-server",
-    "system": "x86_64-linux",
-    "exeName": "cardano-smash-server"
-  },
-  "github:IntersectMBO/cardano-db-sync/bbc1c68370486dc40943fd65f86a285055f2506a#packages.x86_64-linux.cardano-db-sync": {
-    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-db-sync",
-    "version": "sancho-2-1-0",
-    "commit": "bbc1c68370486dc40943fd65f86a285055f2506a",
-    "org_name": "input-output-hk",
-    "repo_name": "cardano-db-sync",
-    "meta": {
-      "available": true,
-      "broken": false,
-      "insecure": false,
-      "name": "cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
-      "outputsToInstall": [
-        "out"
-      ],
-      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
-      "unfree": false,
-      "unsupported": false
-    },
-    "output": "/nix/store/31813j0nr8gz202v9rp5hq48n20fpkci-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
-    "closure": {
-      "fromPath": "/nix/store/31813j0nr8gz202v9rp5hq48n20fpkci-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
-      "toPath": "/nix/store/i695lpqgdlbl64d6487iv6fdij36kzfk-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
-      "fromStore": "https://cache.iog.io"
-    },
-    "pname": "cardano-db-sync-exe-cardano-db-sync",
-    "system": "x86_64-linux",
-    "exeName": "cardano-db-sync"
-  },
-  "github:IntersectMBO/cardano-db-sync/bbc1c68370486dc40943fd65f86a285055f2506a#packages.x86_64-linux.cardano-db-tool": {
-    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-db-tool",
-    "version": "sancho-2-1-0",
-    "commit": "bbc1c68370486dc40943fd65f86a285055f2506a",
-    "org_name": "input-output-hk",
-    "repo_name": "cardano-db-sync",
-    "meta": {
-      "available": true,
-      "broken": false,
-      "insecure": false,
-      "name": "cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
-      "outputsToInstall": [
-        "out"
-      ],
-      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
-      "unfree": false,
-      "unsupported": false
-    },
-    "output": "/nix/store/apgd3al5a3x97f0fw46raks0i2da87sh-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
-    "closure": {
-      "fromPath": "/nix/store/apgd3al5a3x97f0fw46raks0i2da87sh-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
-      "toPath": "/nix/store/2a1y43r94s7bdagvn5a6iwffp0d3macn-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
-      "fromStore": "https://cache.iog.io"
-    },
-    "pname": "cardano-db-tool-exe-cardano-db-tool",
-    "system": "x86_64-linux",
-    "exeName": "cardano-db-tool"
-  },
-  "github:IntersectMBO/cardano-db-sync/bbc1c68370486dc40943fd65f86a285055f2506a#packages.x86_64-linux.cardano-smash-server": {
-    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-smash-server",
-    "version": "sancho-2-1-0",
-    "commit": "bbc1c68370486dc40943fd65f86a285055f2506a",
-    "org_name": "input-output-hk",
-    "repo_name": "cardano-db-sync",
-    "meta": {
-      "available": true,
-      "broken": false,
-      "insecure": false,
-      "name": "cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
-      "outputsToInstall": [
-        "out"
-      ],
-      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
-      "unfree": false,
-      "unsupported": false
-    },
-    "output": "/nix/store/jf883d6dbn4l4fz6w67yg337w9d7hm0x-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
-    "closure": {
-      "fromPath": "/nix/store/jf883d6dbn4l4fz6w67yg337w9d7hm0x-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
-      "toPath": "/nix/store/7lgvznq1q8c8arfqyc87j8knkb706g03-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
-      "fromStore": "https://cache.iog.io"
-    },
-    "pname": "cardano-smash-server-exe-cardano-smash-server",
-    "system": "x86_64-linux",
-    "exeName": "cardano-smash-server"
-  },
-  "github:IntersectMBO/cardano-db-sync/bbc1c68370486dc40943fd65f86a285055f2506a#packages.x86_64-linux.cardano-smash-server-no-basic-auth": {
-    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-smash-server-no-basic-auth",
-    "version": "sancho-2-1-0",
-    "commit": "bbc1c68370486dc40943fd65f86a285055f2506a",
-    "org_name": "input-output-hk",
-    "repo_name": "cardano-db-sync",
-    "meta": {
-      "available": true,
-      "broken": false,
-      "insecure": false,
-      "name": "cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
-      "outputsToInstall": [
-        "out"
-      ],
-      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
-      "unfree": false,
-      "unsupported": false
-    },
-    "output": "/nix/store/hlfasmf98rpxyjv8blsb2yjm29m08hdb-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
-    "closure": {
-      "fromPath": "/nix/store/hlfasmf98rpxyjv8blsb2yjm29m08hdb-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
-      "toPath": "/nix/store/jlwxdsy6kz4p6d2qa070q436wlyq3s2d-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
-      "fromStore": "https://cache.iog.io"
-    },
-    "pname": "cardano-smash-server-exe-cardano-smash-server",
-    "system": "x86_64-linux",
-    "exeName": "cardano-smash-server"
-  },
-  "github:IntersectMBO/cardano-db-sync/c387e78a91f67012f7f43a37d24603611fc9f1c9#packages.x86_64-linux.\"cardano-db-sync:exe:cardano-db-sync\"": {
-    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.\"cardano-db-sync:exe:cardano-db-sync\"",
-    "version": "sancho-4-0-0",
-    "commit": "c387e78a91f67012f7f43a37d24603611fc9f1c9",
-    "org_name": "input-output-hk",
-    "repo_name": "cardano-db-sync",
-    "meta": {
-      "available": true,
-      "broken": false,
-      "insecure": false,
-      "name": "cardano-db-sync-exe-cardano-db-sync-13.2.0.0",
-      "outputsToInstall": [
-        "out"
-      ],
-      "position": "/nix/store/4q1kj9w3iz9pw4l26jjq0bwvlqg4x4am-source/overlays/haskell-nix-extra/default.nix:55",
-      "unfree": false,
-      "unsupported": false
-    },
-    "output": "/nix/store/c2h5nybyqvrf39sc83nzj0say96swkcg-cardano-db-sync-exe-cardano-db-sync-13.2.0.0",
-    "closure": {
-      "fromPath": "/nix/store/c2h5nybyqvrf39sc83nzj0say96swkcg-cardano-db-sync-exe-cardano-db-sync-13.2.0.0",
-      "toPath": "/nix/store/fk4sa3dydpzpykipld6cy3vynzr107ki-cardano-db-sync-exe-cardano-db-sync-13.2.0.0",
-      "fromStore": "https://cache.iog.io"
-    },
-    "pname": "cardano-db-sync-exe-cardano-db-sync",
-    "system": "x86_64-linux",
-    "exeName": "cardano-db-sync"
-  },
-  "github:IntersectMBO/cardano-db-sync/c387e78a91f67012f7f43a37d24603611fc9f1c9#packages.x86_64-linux.\"cardano-db-tool:exe:cardano-db-tool\"": {
-    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.\"cardano-db-tool:exe:cardano-db-tool\"",
-    "version": "sancho-4-0-0",
-    "commit": "c387e78a91f67012f7f43a37d24603611fc9f1c9",
-    "org_name": "input-output-hk",
-    "repo_name": "cardano-db-sync",
-    "meta": {
-      "available": true,
-      "broken": false,
-      "insecure": false,
-      "name": "cardano-db-tool-exe-cardano-db-tool-13.2.0.0",
-      "outputsToInstall": [
-        "out"
-      ],
-      "position": "/nix/store/4q1kj9w3iz9pw4l26jjq0bwvlqg4x4am-source/overlays/haskell-nix-extra/default.nix:55",
-      "unfree": false,
-      "unsupported": false
-    },
-    "output": "/nix/store/bqfxxjz2f6apyc20fvmq9sfsjn1ap8y1-cardano-db-tool-exe-cardano-db-tool-13.2.0.0",
-    "closure": {
-      "fromPath": "/nix/store/bqfxxjz2f6apyc20fvmq9sfsjn1ap8y1-cardano-db-tool-exe-cardano-db-tool-13.2.0.0",
-      "toPath": "/nix/store/azkf41swysrkqr1fa2xih3v36z8izphp-cardano-db-tool-exe-cardano-db-tool-13.2.0.0",
-      "fromStore": "https://cache.iog.io"
-    },
-    "pname": "cardano-db-tool-exe-cardano-db-tool",
-    "system": "x86_64-linux",
-    "exeName": "cardano-db-tool"
-  },
-  "github:IntersectMBO/cardano-db-sync/c387e78a91f67012f7f43a37d24603611fc9f1c9#packages.x86_64-linux.\"cardano-smash-server:exe:cardano-smash-server\"": {
-    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.\"cardano-smash-server:exe:cardano-smash-server\"",
-    "version": "sancho-4-0-0",
-    "commit": "c387e78a91f67012f7f43a37d24603611fc9f1c9",
-    "org_name": "input-output-hk",
-    "repo_name": "cardano-db-sync",
-    "meta": {
-      "available": true,
-      "broken": false,
-      "insecure": false,
-      "name": "cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
-      "outputsToInstall": [
-        "out"
-      ],
-      "position": "/nix/store/4q1kj9w3iz9pw4l26jjq0bwvlqg4x4am-source/overlays/haskell-nix-extra/default.nix:55",
-      "unfree": false,
-      "unsupported": false
-    },
-    "output": "/nix/store/wk0xgrhlsqxls0blxf9yl7y8apvb37wn-cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
-    "closure": {
-      "fromPath": "/nix/store/wk0xgrhlsqxls0blxf9yl7y8apvb37wn-cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
-      "toPath": "/nix/store/c6pf9lsbkvf4dg8sq7lc1krijhjqsdb9-cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
-      "fromStore": "https://cache.iog.io"
-    },
-    "pname": "cardano-smash-server-exe-cardano-smash-server",
-    "system": "x86_64-linux",
-    "exeName": "cardano-smash-server"
-  },
-  "github:IntersectMBO/cardano-db-sync/c387e78a91f67012f7f43a37d24603611fc9f1c9#packages.x86_64-linux.cardano-smash-server-no-basic-auth": {
-    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-smash-server-no-basic-auth",
-    "version": "sancho-4-0-0",
-    "commit": "c387e78a91f67012f7f43a37d24603611fc9f1c9",
-    "org_name": "input-output-hk",
-    "repo_name": "cardano-db-sync",
-    "meta": {
-      "available": true,
-      "broken": false,
-      "insecure": false,
-      "name": "cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
-      "outputsToInstall": [
-        "out"
-      ],
-      "position": "/nix/store/4q1kj9w3iz9pw4l26jjq0bwvlqg4x4am-source/overlays/haskell-nix-extra/default.nix:55",
-      "unfree": false,
-      "unsupported": false
-    },
-    "output": "/nix/store/pjdlb7k22rad6xnlv5l7fd9d10f16k3x-cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
-    "closure": {
-      "fromPath": "/nix/store/pjdlb7k22rad6xnlv5l7fd9d10f16k3x-cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
-      "toPath": "/nix/store/b8g7mkmig46q05h3n75wjl1mb1ia26sx-cardano-smash-server-exe-cardano-smash-server-13.2.0.0",
       "fromStore": "https://cache.iog.io"
     },
     "pname": "cardano-smash-server-exe-cardano-smash-server",
@@ -10249,6 +10473,342 @@
     "system": "x86_64-linux",
     "exeName": "cardano-smash-server"
   },
+  "github:IntersectMBO/cardano-db-sync/d2227a15d95a3bd24ee3b4aff6e25085091b279f#packages.x86_64-linux.cardano-db-sync": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-db-sync",
+    "version": "sancho-2-0-0",
+    "commit": "d2227a15d95a3bd24ee3b4aff6e25085091b279f",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/kj0qz7xw5zrzy2zvd0jd94hwrb2w950i-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
+    "closure": {
+      "fromPath": "/nix/store/kj0qz7xw5zrzy2zvd0jd94hwrb2w950i-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
+      "toPath": "/nix/store/5hgmfchw1ryq8pj5xspbp02mhr8n6jq9-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-db-sync-exe-cardano-db-sync",
+    "system": "x86_64-linux",
+    "exeName": "cardano-db-sync"
+  },
+  "github:IntersectMBO/cardano-db-sync/d2227a15d95a3bd24ee3b4aff6e25085091b279f#packages.x86_64-linux.cardano-db-tool": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-db-tool",
+    "version": "sancho-2-0-0",
+    "commit": "d2227a15d95a3bd24ee3b4aff6e25085091b279f",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/349v213xnirrslr7ypa77d56l7iyy5z1-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
+    "closure": {
+      "fromPath": "/nix/store/349v213xnirrslr7ypa77d56l7iyy5z1-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
+      "toPath": "/nix/store/kk737rh8yyzxchhf75an5102z3qakhp9-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-db-tool-exe-cardano-db-tool",
+    "system": "x86_64-linux",
+    "exeName": "cardano-db-tool"
+  },
+  "github:IntersectMBO/cardano-db-sync/d2227a15d95a3bd24ee3b4aff6e25085091b279f#packages.x86_64-linux.cardano-smash-server": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-smash-server",
+    "version": "sancho-2-0-0",
+    "commit": "d2227a15d95a3bd24ee3b4aff6e25085091b279f",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/q526gspwdz21pmn2hfnyinqcnn8z08c9-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+    "closure": {
+      "fromPath": "/nix/store/q526gspwdz21pmn2hfnyinqcnn8z08c9-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "toPath": "/nix/store/dkgkw8ff3q7jfdkf3dv42n7fahcmw226-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-smash-server-exe-cardano-smash-server",
+    "system": "x86_64-linux",
+    "exeName": "cardano-smash-server"
+  },
+  "github:IntersectMBO/cardano-db-sync/d2227a15d95a3bd24ee3b4aff6e25085091b279f#packages.x86_64-linux.cardano-smash-server-no-basic-auth": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-smash-server-no-basic-auth",
+    "version": "sancho-2-0-0",
+    "commit": "d2227a15d95a3bd24ee3b4aff6e25085091b279f",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/803kpw79cbimhjd64rgcwbm74wqqj15r-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+    "closure": {
+      "fromPath": "/nix/store/803kpw79cbimhjd64rgcwbm74wqqj15r-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "toPath": "/nix/store/i7n0kmazy29nd4as49cghyzq4xjwgwbh-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-smash-server-exe-cardano-smash-server",
+    "system": "x86_64-linux",
+    "exeName": "cardano-smash-server"
+  },
+  "github:IntersectMBO/cardano-db-sync/d249be066beb22a918ed60b4952a2370aca5a28a#packages.x86_64-linux.\"cardano-db-sync:exe:cardano-db-sync\"": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.\"cardano-db-sync:exe:cardano-db-sync\"",
+    "version": "sancho-4.1.0",
+    "commit": "d249be066beb22a918ed60b4952a2370aca5a28a",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-db-sync-exe-cardano-db-sync-13.2.0.1",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/44dywz387yxs2cqba5mmk6ab40phnjsl-source/overlays/haskell-nix-extra/default.nix:55",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/fsq0gpjs0g177pnyg6idjalq4n0hmx9q-cardano-db-sync-exe-cardano-db-sync-13.2.0.1",
+    "closure": {
+      "fromPath": "/nix/store/fsq0gpjs0g177pnyg6idjalq4n0hmx9q-cardano-db-sync-exe-cardano-db-sync-13.2.0.1",
+      "toPath": "/nix/store/h5mnn923vw5s9gwbq801l1wi6d2n69zi-cardano-db-sync-exe-cardano-db-sync-13.2.0.1",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-db-sync-exe-cardano-db-sync",
+    "system": "x86_64-linux",
+    "exeName": "cardano-db-sync"
+  },
+  "github:IntersectMBO/cardano-db-sync/d249be066beb22a918ed60b4952a2370aca5a28a#packages.x86_64-linux.\"cardano-db-tool:exe:cardano-db-tool\"": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.\"cardano-db-tool:exe:cardano-db-tool\"",
+    "version": "sancho-4.1.0",
+    "commit": "d249be066beb22a918ed60b4952a2370aca5a28a",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-db-tool-exe-cardano-db-tool-13.2.0.1",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/44dywz387yxs2cqba5mmk6ab40phnjsl-source/overlays/haskell-nix-extra/default.nix:55",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/ryzqzzfd55xcpiq0x294pma9gsvdh1a9-cardano-db-tool-exe-cardano-db-tool-13.2.0.1",
+    "closure": {
+      "fromPath": "/nix/store/ryzqzzfd55xcpiq0x294pma9gsvdh1a9-cardano-db-tool-exe-cardano-db-tool-13.2.0.1",
+      "toPath": "/nix/store/qpk4ky1m9qq8ps6cm06dbgb5cgnkrldq-cardano-db-tool-exe-cardano-db-tool-13.2.0.1",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-db-tool-exe-cardano-db-tool",
+    "system": "x86_64-linux",
+    "exeName": "cardano-db-tool"
+  },
+  "github:IntersectMBO/cardano-db-sync/d249be066beb22a918ed60b4952a2370aca5a28a#packages.x86_64-linux.\"cardano-smash-server:exe:cardano-smash-server\"": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.\"cardano-smash-server:exe:cardano-smash-server\"",
+    "version": "sancho-4.1.0",
+    "commit": "d249be066beb22a918ed60b4952a2370aca5a28a",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-smash-server-exe-cardano-smash-server-13.2.0.1",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/44dywz387yxs2cqba5mmk6ab40phnjsl-source/overlays/haskell-nix-extra/default.nix:55",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/qn6ch6b6rxpwj6b1q6las1m05d6nrl48-cardano-smash-server-exe-cardano-smash-server-13.2.0.1",
+    "closure": {
+      "fromPath": "/nix/store/qn6ch6b6rxpwj6b1q6las1m05d6nrl48-cardano-smash-server-exe-cardano-smash-server-13.2.0.1",
+      "toPath": "/nix/store/iphbm8047wwim0lxnl3bccns3nmvcmi5-cardano-smash-server-exe-cardano-smash-server-13.2.0.1",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-smash-server-exe-cardano-smash-server",
+    "system": "x86_64-linux",
+    "exeName": "cardano-smash-server"
+  },
+  "github:IntersectMBO/cardano-db-sync/d249be066beb22a918ed60b4952a2370aca5a28a#packages.x86_64-linux.cardano-smash-server-no-basic-auth": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-smash-server-no-basic-auth",
+    "version": "sancho-4.1.0",
+    "commit": "d249be066beb22a918ed60b4952a2370aca5a28a",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-smash-server-exe-cardano-smash-server-13.2.0.1",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/44dywz387yxs2cqba5mmk6ab40phnjsl-source/overlays/haskell-nix-extra/default.nix:55",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/igs5z3f6mpqgjnbzwrc95g0vvvqpqny9-cardano-smash-server-exe-cardano-smash-server-13.2.0.1",
+    "closure": {
+      "fromPath": "/nix/store/igs5z3f6mpqgjnbzwrc95g0vvvqpqny9-cardano-smash-server-exe-cardano-smash-server-13.2.0.1",
+      "toPath": "/nix/store/mnv2q1g4a1rq1sc7czgidgpz3rs4dwwd-cardano-smash-server-exe-cardano-smash-server-13.2.0.1",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-smash-server-exe-cardano-smash-server",
+    "system": "x86_64-linux",
+    "exeName": "cardano-smash-server"
+  },
+  "github:IntersectMBO/cardano-db-sync/d5119ee7d6c3c937cf703d017d8844ee2a1882e8#packages.x86_64-linux.cardano-db-sync": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-db-sync",
+    "version": "sancho-2-0-1",
+    "commit": "d5119ee7d6c3c937cf703d017d8844ee2a1882e8",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/h0pkmd6vbis4cxwy2biszawv9gss060d-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
+    "closure": {
+      "fromPath": "/nix/store/h0pkmd6vbis4cxwy2biszawv9gss060d-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
+      "toPath": "/nix/store/d40802gikrp4hmkymzriccwmryy050ln-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-db-sync-exe-cardano-db-sync",
+    "system": "x86_64-linux",
+    "exeName": "cardano-db-sync"
+  },
+  "github:IntersectMBO/cardano-db-sync/d5119ee7d6c3c937cf703d017d8844ee2a1882e8#packages.x86_64-linux.cardano-db-tool": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-db-tool",
+    "version": "sancho-2-0-1",
+    "commit": "d5119ee7d6c3c937cf703d017d8844ee2a1882e8",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/ykpvzw5h0j5p1qg3y508jmirvak4nhlq-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
+    "closure": {
+      "fromPath": "/nix/store/ykpvzw5h0j5p1qg3y508jmirvak4nhlq-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
+      "toPath": "/nix/store/74xxlk063hs577gscb56vn84d92v3azz-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-db-tool-exe-cardano-db-tool",
+    "system": "x86_64-linux",
+    "exeName": "cardano-db-tool"
+  },
+  "github:IntersectMBO/cardano-db-sync/d5119ee7d6c3c937cf703d017d8844ee2a1882e8#packages.x86_64-linux.cardano-smash-server": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-smash-server",
+    "version": "sancho-2-0-1",
+    "commit": "d5119ee7d6c3c937cf703d017d8844ee2a1882e8",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/kmdmlr8rzwdp3ayd46hsnpc1dfsycfg0-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+    "closure": {
+      "fromPath": "/nix/store/kmdmlr8rzwdp3ayd46hsnpc1dfsycfg0-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "toPath": "/nix/store/mq0jys3f0i9id824cxj05sya02vj287a-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-smash-server-exe-cardano-smash-server",
+    "system": "x86_64-linux",
+    "exeName": "cardano-smash-server"
+  },
+  "github:IntersectMBO/cardano-db-sync/d5119ee7d6c3c937cf703d017d8844ee2a1882e8#packages.x86_64-linux.cardano-smash-server-no-basic-auth": {
+    "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-smash-server-no-basic-auth",
+    "version": "sancho-2-0-1",
+    "commit": "d5119ee7d6c3c937cf703d017d8844ee2a1882e8",
+    "org_name": "input-output-hk",
+    "repo_name": "cardano-db-sync",
+    "meta": {
+      "available": true,
+      "broken": false,
+      "insecure": false,
+      "name": "cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "outputsToInstall": [
+        "out"
+      ],
+      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
+      "unfree": false,
+      "unsupported": false
+    },
+    "output": "/nix/store/c8czl7h8mq60nwbb30w6x3qr69fa4q5l-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+    "closure": {
+      "fromPath": "/nix/store/c8czl7h8mq60nwbb30w6x3qr69fa4q5l-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "toPath": "/nix/store/jlnhswxxfjbg209r6qqidz3cjz8gg511-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "fromStore": "https://cache.iog.io"
+    },
+    "pname": "cardano-smash-server-exe-cardano-smash-server",
+    "system": "x86_64-linux",
+    "exeName": "cardano-smash-server"
+  },
   "github:IntersectMBO/cardano-db-sync/e8a2a344bc0746d1432f0da69c0b333ae6c84f02#packages.x86_64-linux.cardano-db-sync": {
     "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-db-sync",
     "version": "sancho-2-2-0",
@@ -10745,10 +11305,10 @@
     "system": "x86_64-linux",
     "exeName": "cardano-db-tool"
   },
-  "github:IntersectMBO/cardano-db-sync/f296209f075b15855d1e532f5e7ecbc018d53471#packages.x86_64-linux.cardano-db-sync": {
+  "github:IntersectMBO/cardano-db-sync/ffde876ad45ffacf644b985c8843a46596a28e77#packages.x86_64-linux.cardano-db-sync": {
     "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-db-sync",
-    "version": "sancho-1-0-0",
-    "commit": "f296209f075b15855d1e532f5e7ecbc018d53471",
+    "version": "sancho-2-2-0",
+    "commit": "ffde876ad45ffacf644b985c8843a46596a28e77",
     "org_name": "input-output-hk",
     "repo_name": "cardano-db-sync",
     "meta": {
@@ -10759,24 +11319,24 @@
       "outputsToInstall": [
         "out"
       ],
-      "position": "/nix/store/8g0jm7ryhjlidxipgps7491mrlfgs8fw-source/overlays/haskell-nix-extra/default.nix:55",
+      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
       "unfree": false,
       "unsupported": false
     },
-    "output": "/nix/store/mnvfvln6bdj92bjqsxhlk141akj1c8cv-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
+    "output": "/nix/store/hcl8y6h61gxr8wq1lg5bpw8jx5ql212r-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
     "closure": {
-      "fromPath": "/nix/store/mnvfvln6bdj92bjqsxhlk141akj1c8cv-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
-      "toPath": "/nix/store/yd8ws1ngsj37zrw4v6mmk3jq6xqds4kz-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
+      "fromPath": "/nix/store/hcl8y6h61gxr8wq1lg5bpw8jx5ql212r-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
+      "toPath": "/nix/store/3b999glcx8zgb3n15p8h2b5sjxrphblx-cardano-db-sync-exe-cardano-db-sync-13.1.1.3",
       "fromStore": "https://cache.iog.io"
     },
     "pname": "cardano-db-sync-exe-cardano-db-sync",
     "system": "x86_64-linux",
     "exeName": "cardano-db-sync"
   },
-  "github:IntersectMBO/cardano-db-sync/f296209f075b15855d1e532f5e7ecbc018d53471#packages.x86_64-linux.cardano-db-tool": {
+  "github:IntersectMBO/cardano-db-sync/ffde876ad45ffacf644b985c8843a46596a28e77#packages.x86_64-linux.cardano-db-tool": {
     "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-db-tool",
-    "version": "sancho-1-0-0",
-    "commit": "f296209f075b15855d1e532f5e7ecbc018d53471",
+    "version": "sancho-2-2-0",
+    "commit": "ffde876ad45ffacf644b985c8843a46596a28e77",
     "org_name": "input-output-hk",
     "repo_name": "cardano-db-sync",
     "meta": {
@@ -10787,24 +11347,24 @@
       "outputsToInstall": [
         "out"
       ],
-      "position": "/nix/store/8g0jm7ryhjlidxipgps7491mrlfgs8fw-source/overlays/haskell-nix-extra/default.nix:55",
+      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
       "unfree": false,
       "unsupported": false
     },
-    "output": "/nix/store/93jwdhh4gk36nfy2kyphd05dymbw8k49-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
+    "output": "/nix/store/4hxpfpysbmyz40k0ggjcm26f3mqma21a-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
     "closure": {
-      "fromPath": "/nix/store/93jwdhh4gk36nfy2kyphd05dymbw8k49-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
-      "toPath": "/nix/store/5qsk1sc7f2ja6prpgw4lc50jkh23ivyc-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
+      "fromPath": "/nix/store/4hxpfpysbmyz40k0ggjcm26f3mqma21a-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
+      "toPath": "/nix/store/m9mfq1j28dn36dzd7gjp0n25mnisv9mb-cardano-db-tool-exe-cardano-db-tool-13.1.1.3",
       "fromStore": "https://cache.iog.io"
     },
     "pname": "cardano-db-tool-exe-cardano-db-tool",
     "system": "x86_64-linux",
     "exeName": "cardano-db-tool"
   },
-  "github:IntersectMBO/cardano-db-sync/f296209f075b15855d1e532f5e7ecbc018d53471#packages.x86_64-linux.cardano-smash-server": {
+  "github:IntersectMBO/cardano-db-sync/ffde876ad45ffacf644b985c8843a46596a28e77#packages.x86_64-linux.cardano-smash-server": {
     "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-smash-server",
-    "version": "sancho-1-0-0",
-    "commit": "f296209f075b15855d1e532f5e7ecbc018d53471",
+    "version": "sancho-2-2-0",
+    "commit": "ffde876ad45ffacf644b985c8843a46596a28e77",
     "org_name": "input-output-hk",
     "repo_name": "cardano-db-sync",
     "meta": {
@@ -10815,24 +11375,24 @@
       "outputsToInstall": [
         "out"
       ],
-      "position": "/nix/store/8g0jm7ryhjlidxipgps7491mrlfgs8fw-source/overlays/haskell-nix-extra/default.nix:55",
+      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
       "unfree": false,
       "unsupported": false
     },
-    "output": "/nix/store/ahpya23cz57b27wkqi72cf18is300ph1-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+    "output": "/nix/store/2hx63c0wdb0h9bpziy42w78fx8xl9x38-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
     "closure": {
-      "fromPath": "/nix/store/ahpya23cz57b27wkqi72cf18is300ph1-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
-      "toPath": "/nix/store/vbw0ckbmnncps68lvck1d31bmzyx1dik-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "fromPath": "/nix/store/2hx63c0wdb0h9bpziy42w78fx8xl9x38-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "toPath": "/nix/store/lav8q9hnmvx6j8sqibkwzlknaq020d1h-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
       "fromStore": "https://cache.iog.io"
     },
     "pname": "cardano-smash-server-exe-cardano-smash-server",
     "system": "x86_64-linux",
     "exeName": "cardano-smash-server"
   },
-  "github:IntersectMBO/cardano-db-sync/f296209f075b15855d1e532f5e7ecbc018d53471#packages.x86_64-linux.cardano-smash-server-no-basic-auth": {
+  "github:IntersectMBO/cardano-db-sync/ffde876ad45ffacf644b985c8843a46596a28e77#packages.x86_64-linux.cardano-smash-server-no-basic-auth": {
     "name": "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-smash-server-no-basic-auth",
-    "version": "sancho-1-0-0",
-    "commit": "f296209f075b15855d1e532f5e7ecbc018d53471",
+    "version": "sancho-2-2-0",
+    "commit": "ffde876ad45ffacf644b985c8843a46596a28e77",
     "org_name": "input-output-hk",
     "repo_name": "cardano-db-sync",
     "meta": {
@@ -10843,14 +11403,14 @@
       "outputsToInstall": [
         "out"
       ],
-      "position": "/nix/store/8g0jm7ryhjlidxipgps7491mrlfgs8fw-source/overlays/haskell-nix-extra/default.nix:55",
+      "position": "/nix/store/1pzsf1gr27zzj8rkzy1q59dxacshpf5k-source/pkgs/build-support/trivial-builders.nix:87",
       "unfree": false,
       "unsupported": false
     },
-    "output": "/nix/store/h5yprdy9dfnac1b40blvlhclw001s3f1-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+    "output": "/nix/store/k71m8bpqdzzp9zm1qqcsskkf9xh4w72m-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
     "closure": {
-      "fromPath": "/nix/store/h5yprdy9dfnac1b40blvlhclw001s3f1-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
-      "toPath": "/nix/store/767nic1p2skdvvvbazfzffbh52i9qpnp-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "fromPath": "/nix/store/k71m8bpqdzzp9zm1qqcsskkf9xh4w72m-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
+      "toPath": "/nix/store/4saf6b4civa3jcwkd4jg5v8bmwz8r4y8-cardano-smash-server-exe-cardano-smash-server-13.1.1.3",
       "fromStore": "https://cache.iog.io"
     },
     "pname": "cardano-smash-server-exe-cardano-smash-server",
@@ -10859,7 +11419,7 @@
   },
   "github:IntersectMBO/cardano-node/0d98405a60d57e1c8e13406d51cce0e34356bd64#bech32": {
     "name": "github:IntersectMBO/cardano-node/${tag}#bech32",
-    "version": "8.9.0^{}",
+    "version": "8.9.0",
     "commit": "0d98405a60d57e1c8e13406d51cce0e34356bd64",
     "org_name": "input-output-hk",
     "repo_name": "cardano-node",
@@ -10976,7 +11536,7 @@
   },
   "github:IntersectMBO/cardano-node/0d98405a60d57e1c8e13406d51cce0e34356bd64#cardano-cli": {
     "name": "github:IntersectMBO/cardano-node/${tag}#cardano-cli",
-    "version": "8.9.0^{}",
+    "version": "8.9.0",
     "commit": "0d98405a60d57e1c8e13406d51cce0e34356bd64",
     "org_name": "input-output-hk",
     "repo_name": "cardano-node",
@@ -11093,7 +11653,7 @@
   },
   "github:IntersectMBO/cardano-node/0d98405a60d57e1c8e13406d51cce0e34356bd64#cardano-node": {
     "name": "github:IntersectMBO/cardano-node/${tag}#cardano-node",
-    "version": "8.9.0^{}",
+    "version": "8.9.0",
     "commit": "0d98405a60d57e1c8e13406d51cce0e34356bd64",
     "org_name": "input-output-hk",
     "repo_name": "cardano-node",
@@ -11210,7 +11770,7 @@
   },
   "github:IntersectMBO/cardano-node/0d98405a60d57e1c8e13406d51cce0e34356bd64#cardano-submit-api": {
     "name": "github:IntersectMBO/cardano-node/${tag}#cardano-submit-api",
-    "version": "8.9.0^{}",
+    "version": "8.9.0",
     "commit": "0d98405a60d57e1c8e13406d51cce0e34356bd64",
     "org_name": "input-output-hk",
     "repo_name": "cardano-node",
@@ -11327,7 +11887,7 @@
   },
   "github:IntersectMBO/cardano-node/0d98405a60d57e1c8e13406d51cce0e34356bd64#cardano-tracer": {
     "name": "github:IntersectMBO/cardano-node/${tag}#cardano-tracer",
-    "version": "8.9.0^{}",
+    "version": "8.9.0",
     "commit": "0d98405a60d57e1c8e13406d51cce0e34356bd64",
     "org_name": "input-output-hk",
     "repo_name": "cardano-node",
@@ -11444,7 +12004,7 @@
   },
   "github:IntersectMBO/cardano-node/0d98405a60d57e1c8e13406d51cce0e34356bd64#db-analyser": {
     "name": "github:IntersectMBO/cardano-node/${tag}#db-analyser",
-    "version": "8.9.0^{}",
+    "version": "8.9.0",
     "commit": "0d98405a60d57e1c8e13406d51cce0e34356bd64",
     "org_name": "input-output-hk",
     "repo_name": "cardano-node",
@@ -11561,7 +12121,7 @@
   },
   "github:IntersectMBO/cardano-node/0d98405a60d57e1c8e13406d51cce0e34356bd64#db-synthesizer": {
     "name": "github:IntersectMBO/cardano-node/${tag}#db-synthesizer",
-    "version": "8.9.0^{}",
+    "version": "8.9.0",
     "commit": "0d98405a60d57e1c8e13406d51cce0e34356bd64",
     "org_name": "input-output-hk",
     "repo_name": "cardano-node",
@@ -11678,7 +12238,7 @@
   },
   "github:IntersectMBO/cardano-node/0d98405a60d57e1c8e13406d51cce0e34356bd64#db-truncater": {
     "name": "github:IntersectMBO/cardano-node/${tag}#db-truncater",
-    "version": "8.9.0^{}",
+    "version": "8.9.0",
     "commit": "0d98405a60d57e1c8e13406d51cce0e34356bd64",
     "org_name": "input-output-hk",
     "repo_name": "cardano-node",
@@ -30151,7 +30711,7 @@
   },
   "github:input-output-hk/cardano-faucet/ba2a8d9b300a81ccec67aaa32a5dffbdee5e11ad#packages.x86_64-linux.\"cardano-faucet:exe:cardano-faucet\"": {
     "name": "github:input-output-hk/cardano-faucet/${tag}#packages.${system}.\"cardano-faucet:exe:cardano-faucet\"",
-    "version": "master",
+    "version": "8.3",
     "commit": "ba2a8d9b300a81ccec67aaa32a5dffbdee5e11ad",
     "org_name": "input-output-hk",
     "repo_name": "cardano-faucet",

--- a/projects.json
+++ b/projects.json
@@ -14,9 +14,6 @@
       "packages": [
         "github:cardano-foundation/cardano-wallet/${tag}#packages.${system}.cardano-address",
         "github:cardano-foundation/cardano-wallet/${tag}#packages.${system}.cardano-wallet"
-      ],
-      "refs": [
-        "^refs/tags/v\\d{4}-\\d{2}-\\d{2}$"
       ]
     }
   },
@@ -25,9 +22,6 @@
       "github_releases": true,
       "packages": [
         "github:IntersectMBO/cardano-cli/${tag}#packages.${system}.\"cardano-cli:exe:cardano-cli\""
-      ],
-      "refs": [
-        "^refs/tags/cardano-cli-\\d+\\.\\d+\\.\\d+\\.\\d+$"
       ]
     },
     "cardano-db-sync": {
@@ -42,7 +36,8 @@
         "github:IntersectMBO/cardano-db-sync/${tag}#packages.${system}.cardano-smash-server-no-basic-auth"
       ],
       "refs": [
-        "^refs/tags/sancho-\\d+-\\d+-\\d+$"
+        "^refs/tags/sancho-\\d+-\\d+-\\d+\\^\\{\\}$",
+        "^refs/tags/sancho-\\d+\\.\\d+\\.\\d+\\^\\{\\}$"
       ]
     },
     "cardano-faucet": {
@@ -51,7 +46,7 @@
         "github:input-output-hk/cardano-faucet/${tag}#packages.${system}.\"cardano-faucet:exe:cardano-faucet\""
       ],
       "refs": [
-        "^refs/heads/master$"
+        "^refs/tags/\\d+\\.\\d+$"
       ]
     },
     "cardano-node": {
@@ -65,9 +60,6 @@
         "github:IntersectMBO/cardano-node/${tag}#db-analyser",
         "github:IntersectMBO/cardano-node/${tag}#db-synthesizer",
         "github:IntersectMBO/cardano-node/${tag}#db-truncater"
-      ],
-      "refs": [
-        "^refs/tags/8.9.0\\^\\{\\}$"
       ]
     },
     "mithril": {


### PR DESCRIPTION
* Default to recursively dereferenced object sha1 hash for releases
* Still require explicit dereference pattern for refs, but remove the `^{}` pattern from the package name suffix
* Add a shortRev to the package name to disambiguate when a name collision would otherwise occur (ex: annotated tag hash vs. dereferenced commit hash on a release)
* Fix the just rclone recipe for non-CI devshells
* Fix the CI push for PR branches
* Cleanup ref patterns to drop those no longer needed and add dereferencing where applicable